### PR TITLE
Provide 2.1 API

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -45,7 +45,7 @@ $app->post('/oauth2/token', function (Request $request) {
     ]);
 });
 
-$app->get('/api/v2.0/0000-0002-1825-0097/record', function (Request $request) {
+$record = function (Request $request) {
     $body = <<<'EOT'
 {
   "path": "/0000-0002-1825-0097",
@@ -239,7 +239,12 @@ $app->get('/api/v2.0/0000-0002-1825-0097/record', function (Request $request) {
 EOT;
 
     return new Response($body);
-});
+};
+
+// deprecated
+$app->get('/api/v2.0/0000-0002-1825-0097/record', $record);
+
+$app->get('/api/v2.1/0000-0002-1825-0097/record', $record);
 
 $app->error(function (Throwable $e) {
     if ($e instanceof HttpExceptionInterface) {

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -87,7 +87,7 @@ $app->get('/api/v2.0/0000-0002-1825-0097/record', function (Request $request) {
             "source-orcid": {
               "host": "sandbox.orcid.org",
               "path": "0000-0001-8778-8651",
-              "uri": "http://sandbox.orcid.org/0000-0001-8778-8651"
+              "uri": "https://sandbox.orcid.org/0000-0001-8778-8651"
             }
           },
           "department-name": null,
@@ -187,7 +187,7 @@ $app->get('/api/v2.0/0000-0002-1825-0097/record', function (Request $request) {
             "source-orcid": {
               "host": "sandbox.orcid.org",
               "path": "0000-0002-1825-0097",
-              "uri": "http://sandbox.orcid.org/0000-0002-1825-0097"
+              "uri": "https://sandbox.orcid.org/0000-0002-1825-0097"
             }
           },
           "email": "j.carberry@orcid.org",
@@ -233,7 +233,7 @@ $app->get('/api/v2.0/0000-0002-1825-0097/record', function (Request $request) {
   "orcid-identifier": {
     "host": "sandbox.orcid.org",
     "path": "0000-0002-1825-0097",
-    "uri": "http://sandbox.orcid.org/0000-0002-1825-0097"
+    "uri": "https://sandbox.orcid.org/0000-0002-1825-0097"
   }
 }
 EOT;

--- a/test/RecordTest.php
+++ b/test/RecordTest.php
@@ -9,10 +9,19 @@ final class RecordTest extends PHPUnit_Framework_TestCase
 {
     use SilexTestCase;
 
+    public function apiVersions()
+    {
+        return [
+            ['2.0'],
+            ['2.1'],
+        ];
+    }
+
     /**
+     * @dataProvider apiVersions
      * @test
      */
-    public function it_provides_a_record_for_the_user()
+    public function it_provides_a_record_for_the_user($version)
     {
         $response = $this->getApp()->handle(Request::create($a = '/api/v2.1/0000-0002-1825-0097/record'));
 

--- a/test/RecordTest.php
+++ b/test/RecordTest.php
@@ -14,7 +14,7 @@ final class RecordTest extends PHPUnit_Framework_TestCase
      */
     public function it_provides_a_record_for_the_user()
     {
-        $response = $this->getApp()->handle(Request::create($a = '/api/v2.0/0000-0002-1825-0097/record'));
+        $response = $this->getApp()->handle(Request::create($a = '/api/v2.1/0000-0002-1825-0097/record'));
 
         $this->assertSame(
             200,


### PR DESCRIPTION
2.0 is still provided for backward compatibility, but with the same content as 2.1 as it's a small change on ignored fields.